### PR TITLE
Bumping help stable repo following deprecation kubernetes-charts.stor…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN apk add --no-cache \
 # helm
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
 RUN chmod +x /usr/local/bin/helm
-RUN helm repo add stable https://kubernetes-charts.storage.googleapis.com/ && \
+RUN helm repo add stable https://charts.helm.sh/stable && \
     helm repo update;
 
 # kubectl


### PR DESCRIPTION
…age.googleapis.com/. See https://v3.helm.sh/docs/faq/#i-am-getting-a-warning-about-unable-to-get-an-update-from-the-stable-chart-repository